### PR TITLE
Support HTTP Proxy

### DIFF
--- a/src/rendertron.ts
+++ b/src/rendertron.ts
@@ -23,7 +23,11 @@ export class Rendertron {
   private host = process.env.HOST || this.config.host;
 
   async createRenderer(config: Config) {
-    const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+    const args = ['--no-sandbox'];
+    if (process.env.RENDERTRON_HTTP_RPOXY) {
+      args.push('--proxy-server=' + process.env.RENDERTRON_HTTP_RPOXY);
+    }
+    const browser = await puppeteer.launch({ args });
 
     browser.on('disconnected', () => {
       this.createRenderer(config);


### PR DESCRIPTION
In certain cases, Rendertron needs to be run behind an HTTP proxy.

This change will support HTTP proxy when environment variable RENDERTRON_HTTP_RPOXY is set, e.g., http://proxy-www.ebi.ac.uk:3355